### PR TITLE
修复 瞬移至设置坐标 按钮使用玩家当前坐标而非目标坐标

### DIFF
--- a/UntarnishedHeart/Execution/ExecuteAction/Helpers/ExecuteActionDrawHelper.cs
+++ b/UntarnishedHeart/Execution/ExecuteAction/Helpers/ExecuteActionDrawHelper.cs
@@ -76,17 +76,23 @@ internal static class ExecuteActionDrawHelper
         }
     }
 
-    public static unsafe void DrawPositionSelector(string buttonID, Action<Vector3> setPosition)
+    public static unsafe void DrawPositionSelector(string buttonID, Action<Vector3> setPosition, Func<Vector3>? getPosition = null)
     {
         ImGui.SameLine();
         if (ImGuiOm.ButtonIcon($"{buttonID}_GetCurrent", FontAwesomeIcon.Bullseye, "取当前位置", true) &&
             DService.Instance().ObjectTable.LocalPlayer is { } localPlayer0)
             setPosition(localPlayer0.Position);
 
+        if (getPosition == null)
+            return;
+
         ImGui.SameLine();
         if (ImGuiOm.ButtonIcon($"{buttonID}_ToCurrent", FontAwesomeIcon.WheelchairMove, "瞬移至设置坐标", true) &&
             DService.Instance().ObjectTable.LocalPlayer is { } localPlayer1)
-            localPlayer1.ToStruct()->SetPosition(localPlayer1.Position.X, localPlayer1.Position.Y, localPlayer1.Position.Z);
+        {
+            var target = getPosition();
+            localPlayer1.ToStruct()->SetPosition(target.X, target.Y, target.Z);
+        }
     }
 
     public static void DrawNoExtraParametersHint() =>

--- a/UntarnishedHeart/Execution/ExecuteAction/Implementations/MoveToPositionAction.cs
+++ b/UntarnishedHeart/Execution/ExecuteAction/Implementations/MoveToPositionAction.cs
@@ -30,7 +30,7 @@ public sealed class MoveToPositionAction : ExecuteActionBase
         if (ImGui.InputFloat3("位置###MovePositionInput", ref position))
             Position = position;
 
-        ExecuteActionDrawHelper.DrawPositionSelector("MoveGetPosition", currentPosition => Position = currentPosition);
+        ExecuteActionDrawHelper.DrawPositionSelector("MoveGetPosition", currentPosition => Position = currentPosition, () => Position);
     }
 
     protected override bool EqualsCore(ExecuteActionBase other) =>

--- a/UntarnishedHeart/Execution/ExecuteAction/Implementations/UseActionExecuteAction.cs
+++ b/UntarnishedHeart/Execution/ExecuteAction/Implementations/UseActionExecuteAction.cs
@@ -44,7 +44,7 @@ public sealed class UseActionExecuteAction : ExecuteActionBase
         if (ImGui.InputFloat3("地面坐标###UseActionLocation", ref location))
             Location = location;
 
-        ExecuteActionDrawHelper.DrawPositionSelector("UseActionGetCurrentPosition", position => Location = position);
+        ExecuteActionDrawHelper.DrawPositionSelector("UseActionGetCurrentPosition", position => Location = position, () => Location);
     }
 
     protected override bool EqualsCore(ExecuteActionBase other) =>


### PR DESCRIPTION
## 问题

在 MoveToPosition / UseAction (按地面坐标释放) 动作的编辑面板上，`DrawPositionSelector` 提供的「瞬移至设置坐标」按钮实际无效——点击后玩家位置没有变化。

## 原因

`ExecuteActionDrawHelper.DrawPositionSelector` 中该按钮的实现：

\`\`\`csharp
if (ImGuiOm.ButtonIcon(\$\"{buttonID}_ToCurrent\", FontAwesomeIcon.WheelchairMove, \"瞬移至设置坐标\", true) &&
    DService.Instance().ObjectTable.LocalPlayer is { } localPlayer1)
    localPlayer1.ToStruct()->SetPosition(localPlayer1.Position.X, localPlayer1.Position.Y, localPlayer1.Position.Z);
\`\`\`

`SetPosition` 传入的坐标是 `localPlayer1.Position`，也就是玩家当前位置。因此按钮的效果等价于「把玩家瞬移到自己当前位置」，视觉上什么都不会发生。

`DrawPositionSelector` 的签名只接受 `Action<Vector3> setPosition`，拿不到动作里配置的目标坐标，所以要顺带扩展一下。

## 改动

- `DrawPositionSelector` 追加可选参数 `Func<Vector3>? getPosition = null`；当 `getPosition` 为 null 时直接不渲染瞬移按钮（向下兼容其它调用方）
- 瞬移按钮改为从 `getPosition()` 取目标坐标再调 `SetPosition`
- `MoveToPositionAction.Draw` 传入 `() => Position`
- `UseActionExecuteAction.Draw` 传入 `() => Location`

## 测试

本地编译通过，在 MoveToPosition 动作里填入任意 XYZ 坐标后点击瞬移按钮，玩家会正确瞬移到指定坐标。