### PR TITLE
修复 旧预设导入后 MoveToPosition 动作丢失 TypeId 以及动作/条件名称为空

### DIFF
--- a/UntarnishedHeart/Execution/Condition/Configuration/ConditionJSONConverter.cs
+++ b/UntarnishedHeart/Execution/Condition/Configuration/ConditionJSONConverter.cs
@@ -99,8 +99,13 @@ public sealed class ConditionJSONConverter : JsonConverter<ConditionBase>
         var runtimeType        = ConditionJsonTypeRegistry.Instance.GetRuntimeType(typeID);
         var concreteSerializer = PolymorphicJsonSerializerFactory.CreateConcreteTypeSerializer<ConditionBase>();
 
-        return obj.ToObject(runtimeType, concreteSerializer) as ConditionBase ??
-               throw new InvalidOperationException($"无法反序列化条件 TypeId: {typeID}");
+        var condition = obj.ToObject(runtimeType, concreteSerializer) as ConditionBase ??
+                        throw new InvalidOperationException($"无法反序列化条件 TypeId: {typeID}");
+
+        if (string.IsNullOrEmpty(condition.Name))
+            condition.Name = condition.GetDefaultName();
+
+        return condition;
     }
 
     internal static ConditionDetectType ReadConditionKind(JToken? token)

--- a/UntarnishedHeart/Execution/ExecuteAction/Configuration/ExecuteActionJSONConverter.cs
+++ b/UntarnishedHeart/Execution/ExecuteAction/Configuration/ExecuteActionJSONConverter.cs
@@ -59,7 +59,12 @@ public sealed class ExecuteActionJSONConverter : JsonConverter<ExecuteActionBase
         var runtimeType        = ExecuteActionJsonTypeRegistry.Instance.GetRuntimeType(typeID);
         var concreteSerializer = PolymorphicJsonSerializerFactory.CreateConcreteTypeSerializer<ExecuteActionBase>();
 
-        return obj.ToObject(runtimeType, concreteSerializer) as ExecuteActionBase ??
-               throw new InvalidOperationException($"无法反序列化执行动作 TypeId: {typeID}");
+        var action = obj.ToObject(runtimeType, concreteSerializer) as ExecuteActionBase ??
+                     throw new InvalidOperationException($"无法反序列化执行动作 TypeId: {typeID}");
+
+        if (string.IsNullOrEmpty(action.Name))
+            action.Name = action.GetDefaultName();
+
+        return action;
     }
 }

--- a/UntarnishedHeart/Execution/Preset/Configuration/Migrators/PresetStepV3ToV4Migrator.cs
+++ b/UntarnishedHeart/Execution/Preset/Configuration/Migrators/PresetStepV3ToV4Migrator.cs
@@ -60,6 +60,8 @@ internal sealed class PresetStepV3ToV4Migrator : JsonObjectMigratorBase
         var waitForArrival     = PresetStepJsonConverter.ReadBool(migratedMoveAction["WaitForArrival"]);
         var position           = PresetStepJsonConverter.ReadObject(migratedMoveAction["Position"], JsonSerializer.CreateDefault(), default(Vector3));
 
+        migratedMoveAction["TypeId"] = ExecuteActionJsonTypeRegistry.Instance.GetTypeID(ExecuteActionKind.MoveToPosition);
+        migratedMoveAction.Remove("Kind");
         migratedMoveAction["Version"] = ExecuteActionJSONMigrator.CurrentJSONVersion;
         migratedMoveAction.Remove("WaitForArrival");
 


### PR DESCRIPTION
## 问题

从剪贴板导入旧版本导出的预设时，出现以下两种问题：

### 1. 含 MoveToPosition 的旧预设导入失败

`Preset.ImportFromClipboard` 报错（异常被 catch 吞掉只显示「尝试从剪贴板导入预设时发生错误」），实际异常为：

> 执行动作缺少 TypeId

### 2. 导入成功的动作/条件名称为空

动作列表里只能看到 `0.`、`1.` 这种序号，动作和条件的「名称」字段为空串。

## 原因

### 问题 1

`PresetStepV3ToV4Migrator.ExpandAction` 处理 `MoveToPosition` 动作时：

\`\`\`csharp
migratedMoveAction[\"Version\"] = ExecuteActionJSONMigrator.CurrentJSONVersion;
migratedMoveAction.Remove(\"WaitForArrival\");
\`\`\`

直接把 `Version` 提升到当前（3），但**没有把旧的 `Kind` 字段转换成新的 `TypeId`**。之后：

1. 外层对每个动作调用 `ExecuteActionJSONConverter.ReadJson`
2. `ExecuteActionJSONMigrator.ReadVersion` 读到 `Version = 3` 已是当前，跳过整条迁移链（因此 `ExecuteActionV2ToV3Migrator` 的 `Kind → TypeId` 转换不会执行）
3. `DeserializeCurrent` 读不到 `TypeId`，抛 `执行动作缺少 TypeId`
4. 异常沿调用栈冒到 `Preset.ImportFromClipboard` 被 catch 吞掉，用户只看到通用错误

非 `MoveToPosition` 动作不受影响，因为它们只是 `DeepClone` 没被改 `Version`，会正常走完 V1→V2→V3 迁移链。

### 问题 2

老格式的预设步骤里动作是以 `StopInCombat` / `WaitForTargetSpawn` / `Position` 等字段的形式存在的，没有动作级的 Name。`PresetStepV2ToV3Migrator.CreateAction` 合成动作时也没给 Name 赋默认值。反序列化后 `Name` 就是空字符串，UI 里就只剩序号了。条件同理。

`PolymorphicJsonTypeRegistry.InitializeDefaultInstance → ResetMetadata` 只在**新建**实例时设置默认名，对反序列化路径完全不生效。

## 改动

### PresetStepV3ToV4Migrator.cs
对 `MoveToPosition` 动作显式写入 `TypeId` 并移除 `Kind`，语义与 `ExecuteActionV2ToV3Migrator` 保持一致：

\`\`\`csharp
migratedMoveAction[\"TypeId\"] = ExecuteActionJsonTypeRegistry.Instance.GetTypeID(ExecuteActionKind.MoveToPosition);
migratedMoveAction.Remove(\"Kind\");
migratedMoveAction[\"Version\"] = ExecuteActionJSONMigrator.CurrentJSONVersion;
migratedMoveAction.Remove(\"WaitForArrival\");
\`\`\`

### ExecuteActionJSONConverter.cs / ConditionJSONConverter.cs
在 `DeserializeCurrent` 出口统一兜底：若 `Name` 为空则回填 `GetDefaultName()`（即 `Kind.GetDescription()`）。放在反序列化出口能同时覆盖：

- V2→V3 合成出的动作/条件
- V3→V4 MoveToPosition 分支
- `CreateArrivalWaitAction` 这种新建的动作
- 任何未来可能出现的、Name 为空的新迁移路径

只在**空字符串**时回填，不影响用户显式设置的名称。

## 测试

本地用旧预设验证：

- 带 `MoveToPosition` + `WaitForArrival` 的预设导入不再报错
- 动作列表显示「移动到指定位置」「等待固定时间」等默认名称而不是空字符串
- 条件同样显示默认名称